### PR TITLE
Add function to detect Magento 2 project

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
       {
         "command": "magento-developer-tools.openSettings",
         "title": "Settings"
+      },
+      {
+        "command": "magento-developer-tools.checkIfMagento2Project",
+        "title": "Magento Developer Tools: Check if Magento 2 Project"
       }
     ],
     "submenus": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { detectMagento } from "./magento/detect";
+import { detectMagento, checkIfMagento2Project } from "./magento/detect";
 import { createStatusBarItem } from "./status/statusbar";
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -14,7 +14,13 @@ export async function activate(context: vscode.ExtensionContext) {
     },
   );
 
+  let checkMagentoDisposable = vscode.commands.registerCommand(
+    "magento-developer-tools.checkIfMagento2Project",
+    checkIfMagento2Project,
+  );
+
   context.subscriptions.push(disposable);
+  context.subscriptions.push(checkMagentoDisposable);
 }
 
 export function deactivate() {}

--- a/src/magento/detect.ts
+++ b/src/magento/detect.ts
@@ -43,4 +43,31 @@ export async function detectMagento() {
   }
 }
 
+/**
+ * Checks if the current project is a Magento 2 project by searching for the `composer.json` and `app/bootstrap.php` files.
+ * If the files are found, it checks the contents of `composer.json` for the string 'magento/'.
+ * Displays appropriate messages based on the presence and contents of the files.
+ *
+ * @returns A boolean indicating whether the project is a Magento 2 project or not.
+ */
+export async function checkIfMagento2Project() {
+  let composerJson = await vscode.workspace.findFiles('composer.json');
+  let bootstrap = await vscode.workspace.findFiles('./app/bootstrap.php');
+
+  if (composerJson.length === 0 && bootstrap.length === 0) {
+    vscode.window.showErrorMessage('This is not a Magento 2 project');
+    return false;
+  } else {
+    let file = await vscode.workspace.openTextDocument(composerJson[0]);
+    let text = file.getText();
+    if (text.includes('magento/')) {
+      vscode.window.showInformationMessage('This is a Magento 2 project');
+      return true;
+    } else {
+      vscode.window.showErrorMessage('This is not a Magento 2 project');
+      return false;
+    }
+  }
+}
+
 export default detectMagento;


### PR DESCRIPTION
Related to #2

Add a function to detect if a project is a Magento 2 project.

* **src/magento/detect.ts**
  - Add a new function `checkIfMagento2Project` to check for the presence of `composer.json` and `app/bootstrap.php` files.
  - Check the contents of `composer.json` for the string 'magento/'.
  - Display appropriate messages based on the presence and contents of `composer.json` and `app/bootstrap.php` files.
  - Export the `checkIfMagento2Project` function.

* **src/extension.ts**
  - Import the `checkIfMagento2Project` function from `src/magento/detect.ts`.
  - Register a new command `magento-developer-tools.checkIfMagento2Project` that calls `checkIfMagento2Project`.

* **package.json**
  - Add a new command `magento-developer-tools.checkIfMagento2Project` with the title "Magento Developer Tools: Check if Magento 2 Project".


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dermatz/vscode-magento-developer-tools/issues/2?shareId=567a0655-5563-4d3e-8107-8ceae84a1e1f).